### PR TITLE
fix: allow name search without default limit value

### DIFF
--- a/lib/payloads.ts
+++ b/lib/payloads.ts
@@ -227,7 +227,7 @@ export const createModelNameSearchPayload = (
     context,
     attrs = null,
     operator = "ilike",
-    limit = 80,
+    limit,
   } = options;
   return [
     "execute",


### PR DESCRIPTION
Related: https://github.com/gisce/webclient/issues/1279