### PR TITLE
feat: add X-GISCE-Session

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -75,7 +75,7 @@ export class Client {
           headers: {
             "Content-Type": "application/json",
             "X-GISCE-Client": this.clientHeader,
-            "X-GISCE-Session": this.sessionId,
+            ...(this.sessionId !== undefined && { "X-GISCE-Session": this.sessionId }),
           },
           ...options,
         },

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -29,6 +29,7 @@ export class Client {
   token?: string;
   axiosInstance: AxiosInstance | undefined;
   clientHeader?: string;
+  sessionId?: string;
   onTokenAccessDenied?: (error: any) => void;
 
   public setHost(host: string): void {
@@ -74,6 +75,7 @@ export class Client {
           headers: {
             "Content-Type": "application/json",
             "X-GISCE-Client": this.clientHeader,
+            "X-GISCE-Session": this.sessionId,
           },
           ...options,
         },
@@ -182,6 +184,10 @@ export class Client {
 
   public setClientHeader(clientHeader: string): void {
     this.clientHeader = clientHeader;
+  }
+
+  public setSessionId(sessionId: string): void {
+    this.sessionId = sessionId;
   }
 
   public async evalDomain(


### PR DESCRIPTION
This pull request adds support for session management to the `Client` class in `lib/client.ts`. The main changes introduce a new `sessionId` property, allow setting it via a new method, and ensure it is included in request headers for API calls.

**Session management enhancements:**

* Added a `sessionId` property to the `Client` class to store the session identifier.
* Updated the request headers in the `Client` class to include the `X-GISCE-Session` header with the current session ID.
* Added a `setSessionId` method to the `Client` class to allow setting the session ID.